### PR TITLE
Make addon and schema configurable in a separate file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,14 @@
   template: src=colorprompt.sh.j2 dest={{ color_prompt_target_file }} owner=root group=root mode=644
   when: color_prompt_state is defined and color_prompt_state == "present"
 
+- name: Add color prompt config
+  template: src=etc-color-prompt.j2 dest=/etc/color-prompt owner=root group=root mode=644
+  when: color_prompt_state is defined and color_prompt_state == "present"
+
 - name: Remove color prompt script
   file: path={{ color_prompt_target_file }} state=absent
+  when: color_prompt_state is defined and color_prompt_state == "absent"
+
+- name: Remove color prompt config
+  file: path=/etc/color-prompt state=absent
   when: color_prompt_state is defined and color_prompt_state == "absent"

--- a/templates/colorprompt.sh.j2
+++ b/templates/colorprompt.sh.j2
@@ -1,5 +1,13 @@
 #https://wiki.archlinux.org/index.php/Color_Bash_Prompt
 
+schema="{{ color_prompt_schema }}"
+addon="{{ color_prompt_addon }}"
+
+if [ -r "/etc/color-prompt" ]
+then
+	source "/etc/color-prompt"
+fi
+
 # Reset
 Color_Off='\[\e[0m\]'       # Text Reset
 On_Color_Off='\[\e[0m\]'    # Text Reset
@@ -75,8 +83,6 @@ On_ICyan='\[\e[106m\]'    # Cyan
 On_IWhite='\[\e[107m\]'   # White
 
 if [ -n "$BASH_VERSION" ]; then
-	schema="{{ color_prompt_schema }}"
-	addon="{{ color_prompt_addon }}"
 	case $schema in
 {% for schema, colors in color_prompt_schemas.items() %}
 		{{ schema }})

--- a/templates/etc-color-prompt.j2
+++ b/templates/etc-color-prompt.j2
@@ -1,0 +1,2 @@
+schema="{{ color_prompt_schema }}"
+addon="{{ color_prompt_addon }}"


### PR DESCRIPTION
Read defaults from `/etc/color-prompt`.  Easier to provision this file from other sources, i.e. during cloud init.